### PR TITLE
Fixing the problem of not able to link the examples with CMAKE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.0)
+cmake_minimum_required(VERSION 3.13.0)
 project(examples)
 
 # User must provide location of Dyninst cmake files either as a cache or
@@ -24,6 +24,7 @@ if(NOT IS_ABSOLUTE ${_dyninst_dir})
 endif()
 
 set(Dyninst_DIR ${_dyninst_dir} CACHE PATH "Location of Dyninst cmake files")
+get_filename_component(BOOST_ROOT ${_dyninst_dir}/../../../ ABSOLUTE)
 
 # Use the Dyninst-provided CMake modules
 set(CMAKE_MODULE_PATH
@@ -38,8 +39,10 @@ find_package(Dyninst REQUIRED
                         instructionAPI
                         parseAPI
                         symtabAPI
-                        common)
+                        common
+                        )
 
+find_package(Boost 1.61.0 COMPONENTS system REQUIRED)
 # Set default configuration type
 if(NOT CMAKE_BUILD_TYPE)
   set(

--- a/codeCoverage/CMakeLists.txt
+++ b/codeCoverage/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.4.0)
+cmake_minimum_required(VERSION 3.13.0)
 project(codeCoverage LANGUAGES CXX)
 
 # The main code coverage tool
 add_executable(code_coverage code_coverage.C)
 target_include_directories(code_coverage PRIVATE ${DYNINST_INCLUDE_DIR})
-target_link_libraries(code_coverage dyninstAPI)
+target_link_libraries(code_coverage dyninstAPI ${BOOST} ${Boost_SYSTEM_LIBRARY})
 
 # An example instrumentation library
 add_library(Inst SHARED Inst.C)

--- a/instrumentAFunction/CMakeLists.txt
+++ b/instrumentAFunction/CMakeLists.txt
@@ -3,7 +3,7 @@ project(instrumentAFunction LANGUAGES CXX)
 
 add_executable(instrumenting_a_function instrumenting_a_function.cpp)
 target_include_directories(instrumenting_a_function PRIVATE ${DYNINST_INCLUDE_DIR})
-target_link_libraries(instrumenting_a_function dyninstAPI)
+target_link_libraries(instrumenting_a_function dyninstAPI ${Boost_SYSTEM_LIBRARY})
 
 install(TARGETS InterestingProgram 
     RUNTIME DESTINATION ${PROJECT_BINARY_DIR}

--- a/instrumentMemoryAccess/CMakeLists.txt
+++ b/instrumentMemoryAccess/CMakeLists.txt
@@ -2,7 +2,7 @@ project(instrumentMemoryAccess LANGUAGES CXX)
 
 add_executable(instrumenting_memory_access instrumenting_memory_access.cpp)
 target_include_directories(instrumenting_memory_access PRIVATE ${DYNINST_INCLUDE_DIR})
-target_link_libraries(instrumenting_memory_access dyninstAPI instructionAPI)
+target_link_libraries(instrumenting_memory_access dyninstAPI instructionAPI ${Boost_SYSTEM_LIBRARY})
 
 # A dummy target to allow building this example by itself
 add_custom_target(instrumentMemoryAccess DEPENDS instrumenting_memory_access)

--- a/interceptOutput/CMakeLists.txt
+++ b/interceptOutput/CMakeLists.txt
@@ -2,7 +2,7 @@ project(interceptOutput LANGUAGES CXX)
 
 add_executable(retee retee.cpp)
 target_include_directories(retee PRIVATE ${DYNINST_INCLUDE_DIR})
-target_link_libraries(retee dyninstAPI)
+target_link_libraries(retee dyninstAPI ${Boost_SYSTEM_LIBRARY})
 
 # A dummy target to allow building this example by itself
 add_custom_target(interceptOutput DEPENDS retee)

--- a/maxMallocSize/CMakeLists.txt
+++ b/maxMallocSize/CMakeLists.txt
@@ -2,7 +2,7 @@ project(maxMallocSize LANGUAGES CXX)
 
 add_executable(maxMalloc max.cpp)
 target_include_directories(maxMalloc PRIVATE ${DYNINST_INCLUDE_DIR})
-target_link_libraries(maxMalloc dyninstAPI)
+target_link_libraries(maxMalloc dyninstAPI ${Boost_SYSTEM_LIBRARY})
 
 # A dummy target to allow building this example by itself
 add_custom_target(maxMallocSize DEPENDS maxMalloc)

--- a/memoryAccessCounter/CMakeLists.txt
+++ b/memoryAccessCounter/CMakeLists.txt
@@ -2,7 +2,7 @@ project(memoryAccessCounter LANGUAGES CXX)
 
 add_executable(counter counter.cpp)
 target_include_directories(counter PRIVATE ${DYNINST_INCLUDE_DIR})
-target_link_libraries(counter dyninstAPI instructionAPI)
+target_link_libraries(counter dyninstAPI instructionAPI ${Boost_SYSTEM_LIBRARY})
 
 # A dummy target to allow building this example by itself
 add_custom_target(memoryAccessCounter DEPENDS counter)

--- a/unstrip/CMakeLists.txt
+++ b/unstrip/CMakeLists.txt
@@ -17,4 +17,6 @@ target_link_libraries(unstrip
                       instructionAPI
                       parseAPI
                       symtabAPI
-                      common)
+                      common
+                      ${Boost_SYSTEM_LIBRARY}
+                      )


### PR DESCRIPTION
1. Set BOOST_ROOT based on relative path from DYNINST_ROOT
2. Require Boost System
3. Add Boost_SYSTEM_LIBRARY to link target for each examples