### PR TITLE
disassemble: approximate output formatting of objdump

### DIFF
--- a/disassemble/disassemble.cpp
+++ b/disassemble/disassemble.cpp
@@ -13,10 +13,16 @@
 #include "InstructionDecoder.h"
 
 #include <iostream>
+#include <iomanip>
 using namespace std;
 using namespace Dyninst;
 using namespace ParseAPI;
 using namespace InstructionAPI;
+
+// How many bytes of the instruction hex dump should be printed
+// on the first line. The remaining will go to the second line
+// on the assumption that an instruction is at most 15 bytes long.
+static const int l1_width = 7;
 
 int main(int argc, char** argv) {
   if(argc != 2) {
@@ -48,17 +54,13 @@ int main(int argc, char** argv) {
     cout << error;
     return -1;
   }
-  auto fit = all.begin();
-  Function* f = *fit;
   // create an Instruction decoder which will convert the binary opcodes to strings
-  InstructionDecoder decoder(f->isrc()->getPtrToInstruction(f->addr()),
-                             InstructionDecoder::maxInstructionLength, f->region()->getArch());
-  for(; fit != all.end(); ++fit) {
+  InstructionDecoder decoder((const void *)nullptr, 1, sts->getArch());
+  for(auto fit = all.begin(); fit != all.end(); ++fit) {
     Function* f = *fit;
     // get address of entry point for current function
     Address crtAddr = f->addr();
     int instr_count = 0;
-    instr = decoder.decode((unsigned char*)f->isrc()->getPtrToInstruction(crtAddr));
     auto fbl = f->blocks().end();
     fbl--;
     Block* b = *fbl;
@@ -66,12 +68,33 @@ int main(int argc, char** argv) {
     // if current function has zero instructions, d o n t output it
     if(crtAddr == lastAddr)
       continue;
-    cout << "\n\n\"" << f->name() << "\" :";
+    cout << "\n\n" << hex << setfill('0') << setw(2 * sts->getAddressWidth()) << f->addr() << " <" << f->name() << ">:\n";
     while(crtAddr < lastAddr) {
       // decode current instruction
-      instr = decoder.decode((unsigned char*)f->isrc()->getPtrToInstruction(crtAddr));
-      cout << "\n" << hex << crtAddr;
-      cout << ": \"" << instr.format() << "\"";
+      const unsigned char *instr_ptr = (const unsigned char *)f->isrc()->getPtrToInstruction(crtAddr);
+      instr = decoder.decode(instr_ptr);
+
+      // failed to decode the instruction
+      if (instr.size() == 0)
+        break;
+
+      // pretty print it
+      cout << hex << setfill(' ') << setw(8) << crtAddr << ":       ";
+      for (size_t i = 0; i < instr.size() && i < l1_width; i++) {
+        cout << hex << setfill('0') << setw(2) << (unsigned)instr_ptr[i] << " ";
+      }
+      for (size_t i = min(instr.size(), (size_t)l1_width); i < 8; i++) {
+        cout << "   ";
+      }
+      cout << instr.format() << "\n";
+      if (instr.size() > l1_width) {
+        cout << hex << setfill(' ') << setw(8) << crtAddr + l1_width << ":       ";
+        for (size_t i = l1_width; i < instr.size(); i++) {
+          cout << hex << setfill('0') << setw(2) << (unsigned)instr_ptr[i] << " ";
+        }
+        cout << "\n";
+      }
+
       // go to the address of the next instruction
       crtAddr += instr.size();
       instr_count++;


### PR DESCRIPTION
Make output formatting more similar to that of objdump. It makes the result prettier, and opens possibilities for direct output comparison.

Some other changes that happened while adjusting formatting:

* Instruction decoder is created with dummy buffer. The buffer is not used, so making an actual one does nothing.
* Fixed a bug that caused disassemble to freeze if it encountered an invalid (in its understanding) instruction. No_Entry has size 0, so crtAddr didn't advance.